### PR TITLE
Replace pyenchant with pyspellchecker. get rid of quotation marks for typing keyword

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,19 @@ $ /Applications/Python\ 3.x/Install\ Certificates.command
 To query for a certain keyword, run:
 
 ```bash
-$ python3 sotawhat.py "[keyword]" [number of results]
+$ python3 sotawhat.py [keyword] [number of results]
 ```
 
 For example:
 
 ```bash
-$ python3 sotawhat.py "perplexity" 10
+$ python3 sotawhat.py perplexity 10
+```
+
+or 
+
+```bash
+$ python3 sotawhat.py language model 10
 ```
 
 If you don't specify the number of results, by default, the script returns 5 results. Each result contains the title of the paper with author and published date, a summary of the abstract, and link to the paper.
@@ -53,6 +59,6 @@ If you don't specify the number of results, by default, the script returns 5 res
 We've found that this script works well with keywords that are:
 + a model (e.g. transformer, wavenet, ...)
 + a dataset (e.g. wikitext, imagenet, ...)
-+ a task (e.g. 'language model', 'machine translation', 'fuzzing', ...)
++ a task (e.g. language model, machine translation, fuzzing, ...)
 + a metric (e.g. BLEU, perplexity, ...)
 + random stuff

--- a/README.md
+++ b/README.md
@@ -2,11 +2,15 @@
 
 This script runs using Python 3.
 
-First, install the required packages. This script only requires ``nltk`` and ``PyEnchant``.
+## Requirements
+
+First, install the required packages. This script only requires ``nltk`` and ``pyspellchecker``.
 
 ```bash
 $ pip3 install -r requirements.txt
 ```
+
+## Known bugs and fix
 
 If you run the error that the package ``punkt`` doesn't exist, download it by going into your Python environment and running:
 
@@ -30,6 +34,7 @@ this will be fixed by reinstalling certificates
 $ /Applications/Python\ 3.x/Install\ Certificates.command
 ```
 
+## Usage
 
 To query for a certain keyword, run:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-PyEnchant
+pyspellchecker
 nltk

--- a/sotawhat.py
+++ b/sotawhat.py
@@ -271,9 +271,9 @@ def main():
     try:
         num_results = int(sys.argv[-1])
         assert num_results > 0, 'You must choose to show a positive number of results'
-        keyword = ' '.join([arg for arg in sys.argv[1:-1]])
+        keyword = ' '.join(sys.argv[1:-1])
     except ValueError:
-        keyword = ' '.join([arg for arg in sys.argv[1:]])
+        keyword = ' '.join(sys.argv[1:])
         num_results = 5
 
     get_papers(keyword, num_results)

--- a/sotawhat.py
+++ b/sotawhat.py
@@ -2,7 +2,7 @@ import re
 import sys
 import urllib.error
 import urllib.request
-import enchant
+from spellchecker import SpellChecker
 from nltk.tokenize import word_tokenize
 from six.moves.html_parser import HTMLParser
 
@@ -31,7 +31,7 @@ def get_authors(lines, i):
 def get_next_result(lines, start):
     """
     Extract paper from the xml file obtained from arxiv search.
-    
+
     Each paper is a dict that contains:
     + 'title': str
     + 'pdf_link': str
@@ -224,8 +224,9 @@ def get_papers(keyword, num_results=5):
         keyword = keyword.lower()
     else:
         keyword = keyword.lower()
-        d = enchant.Dict('en_US')
-        if d.check(keyword):
+        words = keyword.split()
+        d = SpellChecker()
+        if not d.unknown(words):
             query_temp = 'https://arxiv.org/search/advanced?advanced=&terms-0-operator=AND&terms-0-term={}&terms-0-field=all&classification-computer_science=y&classification-physics_archives=all&date-filter_by=all_dates&date-year=&date-from_date=&date-to_date=&date-date_type=submitted_date&abstracts=show&size={}&order=-announced_date_first&start={}'
         else:
             query_temp = 'https://arxiv.org/search/?searchtype=all&query={}&abstracts=show&size={}&order=-announced_date_first&start={}'
@@ -266,21 +267,13 @@ def get_papers(keyword, num_results=5):
 def main():
     if len(sys.argv) < 2:
         raise ValueError('You must specify a keyword')
-    if len(sys.argv) > 3:
-        raise ValueError("Too many arguments")
 
-    keyword = sys.argv[1]
-
-    if len(sys.argv) == 3:
-        try:
-            num_results = int(sys.argv[2])
-        except:
-            print('The second argument must be an integer')
-            return
-        if num_results <= 0:
-            raise ValueError('You must choose to show a positive number of results')
-
-    else:
+    try:
+        num_results = int(sys.argv[-1])
+        assert num_results > 0, 'You must choose to show a positive number of results'
+        keyword = ' '.join([arg for arg in sys.argv[1:-1]])
+    except ValueError:
+        keyword = ' '.join([arg for arg in sys.argv[1:]])
         num_results = 5
 
     get_papers(keyword, num_results)


### PR DESCRIPTION
Thanks for the useful script. Since pyenchant is no longer supported, I replaced it with pyspellchecker, which i verified to work in both Linux and Windows, and also removed the need for quotation marks for keyword on shell.
Best,
