### PR TITLE
Making sotawhat instantly usable to docker users

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.6.6-alpine
+
+RUN apk add --no-cache \
+  enchant \
+  #tini \
+  aspell-en
+
+
+COPY requirements.txt /
+RUN pip install -r /requirements.txt && \
+  #todo: download file directly to prevent re-download
+  python -c "import nltk; nltk.download('punkt')"
+
+COPY . /app
+WORKDIR /app
+
+
+#ENTRYPOINT ["/sbin/tini", "--", "python", "--", "sotawhat.py"]
+ENTRYPOINT ["python", "--", "sotawhat.py"]
+

--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ For example:
 $ python3 sotawhat.py "perplexity" 10
 ```
 
+If you are using docker:
+
+```bash
+$ docker run --rm -it bulletninja/sotawhat "perplexity" 10
+```
+
 If you don't specify the number of results, by default, the script returns 5 results. Each result contains the title of the paper with author and published date, a summary of the abstract, and link to the paper.
 
 We've found that this script works well with keywords that are:


### PR DESCRIPTION
It can be run from docker hub like this `docker run --rm -it bulletninja/sotawhat "perplexity" 10` 
or you can build your own image.