### PR TITLE
Remove Deprecation warnings

### DIFF
--- a/sotawhat.py
+++ b/sotawhat.py
@@ -5,6 +5,7 @@ import urllib.request
 import enchant
 from nltk.tokenize import word_tokenize
 from six.moves.html_parser import HTMLParser
+import html
 
 h = HTMLParser()
 
@@ -174,9 +175,9 @@ def extract_line(abstract, keyword, limit):
 
 def get_report(paper, keyword):
     if keyword in paper['abstract'].lower():
-        title = h.unescape(paper['title'])
+        title = html.unescape(paper['title'])
         headline = '{} ({} - {})\n'.format(title, paper['authors'][0], paper['date'])
-        abstract = h.unescape(paper['abstract'])
+        abstract = html.unescape(paper['abstract'])
         extract, has_number = extract_line(abstract, keyword, 280 - len(headline))
         if extract:
             report = headline + extract + '\nLink: {}'.format(paper['main_page'])


### PR DESCRIPTION
Use html.unescape instead of h.unescape to remove deprecation warnings on Python 3.7 in Windows