### PR TITLE
Prettify report in get_report() by using Python's in-built package termcolor

### DIFF
--- a/sotawhat.py
+++ b/sotawhat.py
@@ -5,6 +5,7 @@ import urllib.request
 import enchant
 from nltk.tokenize import word_tokenize
 from six.moves.html_parser import HTMLParser
+from termcolor import colored
 
 h = HTMLParser()
 
@@ -174,12 +175,25 @@ def extract_line(abstract, keyword, limit):
 
 def get_report(paper, keyword):
     if keyword in paper['abstract'].lower():
-        title = h.unescape(paper['title'])
-        headline = '{} ({} - {})\n'.format(title, paper['authors'][0], paper['date'])
-        abstract = h.unescape(paper['abstract'])
-        extract, has_number = extract_line(abstract, keyword, 280 - len(headline))
+
+        # Title of paper
+        title = '\n{}\n'.format(h.unescape(paper['title']))
+        title_colored = colored(title, 'yellow')
+        # Authors and date
+        subtitle = '{} on {}\n'.format(paper['authors'][0], paper['date'])
+        subtitle_colored = colored(subtitle, 'green')
+        # Abstract
+        abstract = '{}\n'.format(h.unescape(paper['abstract']))
+        extract, has_number = extract_line(abstract, keyword, 280 - len(title))
+        if extract[-1] == '\n':
+            extract = extract[:-1]
+        extract_colored = '{}'.format(colored(extract))
+        # Link to paper
+        link = '\nLink: {}'.format(paper['main_page'])
+        link_colored = colored(link, 'blue')
+
         if extract:
-            report = headline + extract + '\nLink: {}'.format(paper['main_page'])
+            report = title_colored + subtitle_colored + extract_colored + link_colored
             return report, has_number
     return '', False
 
@@ -205,12 +219,12 @@ def txt2reports(txt, keyword, num_to_show):
 
             if has_number:
                 print(report)
-                print('====================================================')
                 num_to_show -= 1
             elif report:
                 unshown.append(report)
         if line == '</ol>':
             break
+
     return unshown, num_to_show, found
 
 


### PR DESCRIPTION
Pull request to prettify report for better readability. (I love this initiative btw)
1) Added one line of import statement. 
2) Made changes to get_report() by applying termcolor.coloured() on string variables.

Example of a report:
![screenshot 2018-10-09 at 5 26 38 pm](https://user-images.githubusercontent.com/11023859/46659954-89d3a400-cbe8-11e8-9a88-9c80c64b7d23.png)

