### PR TITLE
Add .gitignore for .python-version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.python-version


### PR DESCRIPTION
`.python-version` allows overriding the Python version used on a per-directory basis in [pyenv](https://github.com/pyenv/pyenv).
For those of us using it, nice to have it ignored.