### PR TITLE
Fix arxiv url extraction

### DIFF
--- a/sotawhat/sotawhat.py
+++ b/sotawhat/sotawhat.py
@@ -50,10 +50,18 @@ def get_next_result(lines, start):
     """
 
     result = {}
-    idx = lines[start + 3][10:].find('"')
-    result['main_page'] = lines[start + 3][9:10 + idx]
-    idx = lines[start + 4][23:].find('"')
-    result['pdf'] = lines[start + 4][22: 23 + idx] + '.pdf'
+
+    # these can change with arxiv updates
+    abstract_line = 2
+    abstract_begin_offset = 47
+
+    pdf_line = 3
+    pdf_begin_offset = 22
+
+    idx = lines[start + abstract_line][abstract_begin_offset:].find('"')
+    result['main_page'] = lines[start + abstract_line][abstract_begin_offset:abstract_begin_offset + idx]
+    idx = lines[start + pdf_line][pdf_begin_offset:].find('"')
+    result['pdf'] = lines[start + pdf_line][pdf_begin_offset: pdf_begin_offset + idx] + '.pdf'
 
     start += 4
 


### PR DESCRIPTION
Fixes #23 

Arxiv changed their layout so I updated the line indices / starting points accordingly. Gave them names so further updates might be easier to update & debug. I tested briefly on Ubuntu / python 3.6, but this is raw string indexing so it _shouldn't_ break anything cross platform.

```
> sotawhat object detection
Improve Object Detection by Data Enhancement based on Generative Adversarial Nets (Wei Jiang - 5 March, 2019)
The accuracy of the object detection model depends on whether the anchor boxes effectively trained. Our model with 321x321 input achieves 78.7% mAP on the VOC2007 test, 76.6% mAP on the VOC2012 test.
Link: https://arxiv.org/abs/1903.01716
```
