### PR TITLE
Fix for Python 3.9+/current arXiv + switch to the official arXiv API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+venv/
+build/
+*.egg-info/
+__pycache__/
+*.pyc
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -6,7 +6,13 @@ Read more about SOTAWHAT [here](https://huyenchip.com/2018/10/04/sotawhat.html).
 
 You can use sotawhat through a web interface [here](https://sotawhat.herokuapp.com/#/). Thanks hmchuong!
 
-This script runs using Python 3. It requires ``nltk``, ``six``, and ``pyspellchecker``. To install it as a Python package, follow the following steps:
+This fork queries the official [arXiv API](https://info.arxiv.org/help/api/index.html)
+(public, no registration or API key required) and parses the returned Atom XML,
+instead of scraping arXiv's search HTML. This makes it far more resilient to
+website layout changes. SSL certificates are configured automatically via
+``certifi``, so the macOS certificate error below no longer requires manual setup.
+
+This script runs using Python 3. It requires ``nltk``, ``pyspellchecker``, and ``certifi``. To install it as a Python package, follow the following steps:
 
 
 Step 1: clone this repo, and go inside that repo:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 nltk
 six
 pyspellchecker
+certifi

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 nltk
-six
 pyspellchecker
 certifi

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
                          'abstracts and extract summaries from them. '),
     url='https://huyenchip.com/2018/10/04/sotawhat.html',
     license="",
-    install_requires=['six', 'nltk', 'pyspellchecker', 'certifi'],
+    install_requires=['nltk', 'pyspellchecker', 'certifi'],
     entry_points={
         'console_scripts': ['sotawhat=sotawhat.sotawhat:main'],
     }

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
                          'abstracts and extract summaries from them. '),
     url='https://huyenchip.com/2018/10/04/sotawhat.html',
     license="",
-    install_requires=['six', 'nltk', 'pyspellchecker'],
+    install_requires=['six', 'nltk', 'pyspellchecker', 'certifi'],
     entry_points={
         'console_scripts': ['sotawhat=sotawhat.sotawhat:main'],
     }

--- a/sotawhat/sotawhat.py
+++ b/sotawhat/sotawhat.py
@@ -1,5 +1,7 @@
+import html
 import os
 import re
+import ssl
 import sys
 import urllib.error
 import urllib.request
@@ -7,15 +9,23 @@ import warnings
 
 import nltk
 from nltk.tokenize import word_tokenize
-from six.moves.html_parser import HTMLParser
 from spellchecker import SpellChecker
+
+# On macOS the system Python often can't verify SSL certs out of the box,
+# breaking both nltk downloads and arxiv requests. Point the default HTTPS
+# context at certifi's bundle so the tool works without extra setup.
+try:
+    import certifi
+    ssl._create_default_https_context = (
+        lambda *a, **k: ssl.create_default_context(cafile=certifi.where())
+    )
+except ImportError:
+    pass
 
 try:
     nltk.data.find('tokenizers/punkt')
 except LookupError:
     nltk.download('punkt')
-
-h = HTMLParser()
 
 AUTHOR_TAG = '<a href="/search/?searchtype=author'
 TITLE_TAG = '<p class="title is-5 mathjax">'
@@ -50,10 +60,24 @@ def get_next_result(lines, start):
     """
 
     result = {}
-    idx = lines[start + 3][10:].find('"')
-    result['main_page'] = lines[start + 3][9:10 + idx]
-    idx = lines[start + 4][23:].find('"')
-    result['pdf'] = lines[start + 4][22: 23 + idx] + '.pdf'
+    # Find the abstract page link (.../abs/<id>) and pdf link (.../pdf/<id>)
+    # within the first few lines of this result block. arXiv's markup shifts
+    # over time, so match by URL pattern rather than fixed line offsets.
+    main_page = ''
+    pdf = ''
+    for line in lines[start:start + 8]:
+        if not main_page:
+            m = re.search(r'href="(https?://arxiv\.org/abs/[^"]+)"', line)
+            if m:
+                main_page = m.group(1)
+        if not pdf:
+            m = re.search(r'href="(https?://arxiv\.org/pdf/[^"]+)"', line)
+            if m:
+                pdf = m.group(1)
+        if main_page and pdf:
+            break
+    result['main_page'] = main_page
+    result['pdf'] = pdf if pdf.endswith('.pdf') else pdf + '.pdf'
 
     start += 4
 
@@ -183,9 +207,9 @@ def extract_line(abstract, keyword, limit):
 
 def get_report(paper, keyword):
     if keyword in paper['abstract'].lower():
-        title = h.unescape(paper['title'])
+        title = html.unescape(paper['title'])
         headline = '{} ({} - {})\n'.format(title, paper['authors'][0], paper['date'])
-        abstract = h.unescape(paper['abstract'])
+        abstract = html.unescape(paper['abstract'])
         extract, has_number = extract_line(abstract, keyword, 280 - len(headline))
         if extract:
             report = headline + extract + '\nLink: {}'.format(paper['main_page'])
@@ -195,7 +219,8 @@ def get_report(paper, keyword):
 
 def txt2reports(txt, keyword, num_to_show):
     found = False
-    txt = ''.join(chr(c) for c in txt)
+    if isinstance(txt, (bytes, bytearray)):
+        txt = txt.decode('utf-8', errors='replace')
     lines = txt.split('\n')
     lines = clean_empty_lines(lines)
     unshown = []

--- a/sotawhat/sotawhat.py
+++ b/sotawhat/sotawhat.py
@@ -3,9 +3,13 @@ import os
 import re
 import ssl
 import sys
+import time
 import urllib.error
+import urllib.parse
 import urllib.request
 import warnings
+import xml.etree.ElementTree as ET
+from datetime import datetime
 
 import nltk
 from nltk.tokenize import word_tokenize
@@ -27,97 +31,13 @@ try:
 except LookupError:
     nltk.download('punkt')
 
-AUTHOR_TAG = '<a href="/search/?searchtype=author'
-TITLE_TAG = '<p class="title is-5 mathjax">'
-ABSTRACT_TAG = '<span class="abstract-full has-text-grey-dark mathjax"'
-DATE_TAG = '<p class="is-size-7"><span class="has-text-black-bis has-text-weight-semibold">Submitted</span>'
-
-
-def get_authors(lines, i):
-    authors = []
-    while True:
-        if not lines[i].startswith(AUTHOR_TAG):
-            break
-        idx = lines[i].find('>')
-        if lines[i].endswith(','):
-            authors.append(lines[i][idx + 1: -5])
-        else:
-            authors.append(lines[i][idx + 1: -4])
-        i += 1
-    return authors, i
-
-
-def get_next_result(lines, start):
-    """
-    Extract paper from the xml file obtained from arxiv search.
-
-    Each paper is a dict that contains:
-    + 'title': str
-    + 'pdf_link': str
-    + 'main_page': str
-    + 'authors': []
-    + 'abstract': str
-    """
-
-    result = {}
-    # Find the abstract page link (.../abs/<id>) and pdf link (.../pdf/<id>)
-    # within the first few lines of this result block. arXiv's markup shifts
-    # over time, so match by URL pattern rather than fixed line offsets.
-    main_page = ''
-    pdf = ''
-    for line in lines[start:start + 8]:
-        if not main_page:
-            m = re.search(r'href="(https?://arxiv\.org/abs/[^"]+)"', line)
-            if m:
-                main_page = m.group(1)
-        if not pdf:
-            m = re.search(r'href="(https?://arxiv\.org/pdf/[^"]+)"', line)
-            if m:
-                pdf = m.group(1)
-        if main_page and pdf:
-            break
-    result['main_page'] = main_page
-    result['pdf'] = pdf if pdf.endswith('.pdf') else pdf + '.pdf'
-
-    start += 4
-
-    while lines[start].strip() != TITLE_TAG:
-        start += 1
-
-    title = lines[start + 1].strip()
-    title = title.replace('<span class="search-hit mathjax">', '')
-    title = title.replace('</span>', '')
-    result['title'] = title
-
-    authors, start = get_authors(lines, start + 5)  # orig: add 8
-
-    while not lines[start].strip().startswith(ABSTRACT_TAG):
-        start += 1
-    abstract = lines[start + 1]
-    abstract = abstract.replace('<span class="search-hit mathjax">', '')
-    abstract = abstract.replace('</span>', '')
-    result['abstract'] = abstract
-
-    result['authors'] = authors
-
-    while not lines[start].strip().startswith(DATE_TAG):
-        start += 1
-
-    idx = lines[start].find('</span> ')
-    end = lines[start][idx:].find(';')
-
-    result['date'] = lines[start][idx + 8: idx + end]
-
-    return result, start
-
-
-def clean_empty_lines(lines):
-    cleaned = []
-    for line in lines:
-        line = line.strip()
-        if line:
-            cleaned.append(line)
-    return cleaned
+# arXiv's official, public, no-registration API. Returns Atom XML.
+# Docs + terms of use: https://info.arxiv.org/help/api/index.html
+API_URL = 'http://export.arxiv.org/api/query'
+ATOM_NS = '{http://www.w3.org/2005/Atom}'
+PAGE_SIZE = 100        # entries to request per API call
+MAX_PAGES = 10         # safety cap so we never loop forever
+REQUEST_DELAY = 3.0    # seconds between calls (arXiv asks for >= 3s)
 
 
 def is_float(token):
@@ -217,85 +137,143 @@ def get_report(paper, keyword):
     return '', False
 
 
-def txt2reports(txt, keyword, num_to_show):
-    found = False
-    if isinstance(txt, (bytes, bytearray)):
-        txt = txt.decode('utf-8', errors='replace')
-    lines = txt.split('\n')
-    lines = clean_empty_lines(lines)
-    unshown = []
+def format_date(published):
+    """Convert an Atom timestamp (2026-06-18T17:59:05Z) to '18 June, 2026'."""
+    try:
+        dt = datetime.strptime(published[:10], '%Y-%m-%d')
+        return dt.strftime('%-d %B, %Y')
+    except (ValueError, TypeError):
+        return published
 
-    for i in range(len(lines)):
-        if num_to_show <= 0:
-            return unshown, num_to_show, found
 
-        line = lines[i].strip()
-        if len(line) == 0:
-            continue
-        if line == '<li class="arxiv-result">':
-            found = True
-            paper, i = get_next_result(lines, i)
-            report, has_number = get_report(paper, keyword)
+def parse_entry(entry):
+    """Turn one Atom <entry> element into a paper dict."""
+    def text(tag):
+        node = entry.find(ATOM_NS + tag)
+        return node.text.strip() if node is not None and node.text else ''
 
-            if has_number:
-                print(report)
-                print('====================================================')
-                num_to_show -= 1
-            elif report:
-                unshown.append(report)
-        if line == '</ol>':
-            break
-    return unshown, num_to_show, found
+    paper = {}
+    # Collapse the whitespace arXiv puts inside <title>/<summary>.
+    paper['title'] = ' '.join(text('title').split())
+    paper['abstract'] = ' '.join(text('summary').split())
+    paper['date'] = format_date(text('published'))
+
+    authors = []
+    for author in entry.findall(ATOM_NS + 'author'):
+        name = author.find(ATOM_NS + 'name')
+        if name is not None and name.text:
+            authors.append(name.text.strip())
+    paper['authors'] = authors
+
+    # <id> is the canonical abstract page; force https.
+    paper['main_page'] = text('id').replace('http://', 'https://')
+    paper['pdf'] = ''
+    for link in entry.findall(ATOM_NS + 'link'):
+        if link.get('title') == 'pdf':
+            paper['pdf'] = link.get('href', '').replace('http://', 'https://')
+    return paper
+
+
+def build_query(keyword):
+    """
+    Build the arXiv API search_query.
+
+    If the keyword is plain English, restrict to the computer-science archive
+    to avoid ambiguous hits from other fields (e.g. 'transformer' in physics).
+    Unknown words (model/dataset jargon) are searched across all of arXiv.
+    """
+    keyword = keyword.lower()
+    words = keyword.split()
+    cs_only = keyword in set(['gan', 'bpc'])
+    if not cs_only:
+        spell = SpellChecker()
+        cs_only = not spell.unknown(words)
+
+    search = 'all:{}'.format(keyword)
+    if cs_only:
+        search += ' AND cat:cs.*'
+    return search
+
+
+def fetch_page(search_query, start):
+    params = urllib.parse.urlencode({
+        'search_query': search_query,
+        'start': start,
+        'max_results': PAGE_SIZE,
+        'sortBy': 'submittedDate',
+        'sortOrder': 'descending',
+    })
+    req = urllib.request.Request(API_URL + '?' + params)
+    response = urllib.request.urlopen(req)
+    return response.read()
 
 
 def get_papers(keyword, num_results=5):
-    """
-    If keyword is an English word, then search in CS category only to avoid papers from other categories, resulted from the ambiguity
-    """
+    keyword = keyword.lower()
+    search_query = build_query(keyword)
 
-    if keyword in set(['GAN', 'bpc']):
-        query_temp = 'https://arxiv.org/search/advanced?advanced=&terms-0-operator=AND&terms-0-term={}&terms-0-field=all&classification-computer_science=y&classification-physics_archives=all&date-filter_by=all_dates&date-year=&date-from_date=&date-to_date=&date-date_type=submitted_date&abstracts=show&size={}&order=-announced_date_first&start={}'
-        keyword = keyword.lower()
-    else:
-        keyword = keyword.lower()
-        words = keyword.split()
-        d = SpellChecker()
-        if not d.unknown(words):
-            query_temp = 'https://arxiv.org/search/advanced?advanced=&terms-0-operator=AND&terms-0-term={}&terms-0-field=all&classification-computer_science=y&classification-physics_archives=all&date-filter_by=all_dates&date-year=&date-from_date=&date-to_date=&date-date_type=submitted_date&abstracts=show&size={}&order=-announced_date_first&start={}'
-        else:
-            query_temp = 'https://arxiv.org/search/?searchtype=all&query={}&abstracts=show&size={}&order=-announced_date_first&start={}'
-    keyword_q = keyword.replace(' ', '+')
-    page = 0
-    per_page = 200
-    num_to_show = num_results
-    all_unshown = []
+    shown = 0
+    unshown = []          # papers that mention the keyword but report no numbers
+    any_results = False
 
-    while num_to_show > 0:
-        query = query_temp.format(keyword_q, str(per_page), str(per_page * page))
+    for page in range(MAX_PAGES):
+        if shown >= num_results:
+            break
 
-        req = urllib.request.Request(query)
         try:
-            response = urllib.request.urlopen(req)
+            raw = fetch_page(search_query, page * PAGE_SIZE)
         except urllib.error.HTTPError as e:
-            print('Error {}: problem accessing the server'.format(e.code))
+            print('Error {}: problem accessing the arXiv API'.format(e.code))
+            return
+        except urllib.error.URLError as e:
+            print('Error: could not reach the arXiv API ({})'.format(e.reason))
             return
 
-        txt = response.read()
-        unshown, num_to_show, found = txt2reports(txt, keyword, num_to_show)
-        if not found and not all_unshown and num_to_show == num_results:
-            print('Sorry, we were unable to find any abstract with the word {}'.format(keyword))
+        try:
+            root = ET.fromstring(raw)
+        except ET.ParseError:
+            print('Error: could not parse the arXiv API response')
             return
 
-        if num_to_show < num_results / 2 or not found:
-            for report in all_unshown[:num_to_show]:
+        entries = root.findall(ATOM_NS + 'entry')
+        if not entries:
+            break  # no more papers to page through
+
+        for entry in entries:
+            if shown >= num_results:
+                break
+            any_results = True
+            paper = parse_entry(entry)
+            if not paper['authors']:
+                continue
+            report, paper_has_number = get_report(paper, keyword)
+            if paper_has_number:
                 print(report)
                 print('====================================================')
-            if not found:
-                return
-            num_to_show -= len(all_unshown)
+                shown += 1
+            elif report:
+                unshown.append(report)
+
+        if len(entries) < PAGE_SIZE:
+            break  # last page reached
+
+        if shown < num_results and page < MAX_PAGES - 1:
+            time.sleep(REQUEST_DELAY)  # be polite to arXiv
+
+    # Fall back to keyword-mentioning papers without numeric results.
+    if shown < num_results and unshown:
+        for report in unshown[:num_results - shown]:
+            print(report)
+            print('====================================================')
+            shown += 1
+
+    if shown == 0:
+        if any_results:
+            print('Sorry, we found papers but none with a usable abstract '
+                  'summary for the word {}'.format(keyword))
         else:
-            all_unshown.extend(unshown)
-        page += 1
+            print('Sorry, we were unable to find any abstract with the word '
+                  '{}'.format(keyword))
 
 
 def main():
@@ -319,7 +297,6 @@ def main():
     except ValueError:
         keyword = ' '.join(sys.argv[1:])
         num_results = 5
-
 
     get_papers(keyword, num_results)
 


### PR DESCRIPTION
## Summary

This PR gets `sotawhat` working again on modern Python and a current arXiv, and makes it resilient to future arXiv changes. The script had stopped working on Python 3.9+ and against arXiv's current site.

## Fixes (script was broken on Python 3.9+ / current arXiv)

- Replace removed `HTMLParser.unescape()` with `html.unescape()` (removed in Python 3.9).
- Fix garbled paper links and author-name mojibake (proper UTF-8 decoding of the response).
- Auto-configure SSL via `certifi`, so `nltk` downloads and arXiv requests work on macOS without the manual "Install Certificates" step.

## Improvement: use the official arXiv API

- Switch from scraping arXiv's search **HTML** to the official, public, no-registration [arXiv API](https://info.arxiv.org/help/api/index.html), parsing the structured Atom XML with `xml.etree.ElementTree`. This removes the brittleness that broke the tool whenever arXiv changed its page layout.
- Polite `>= 3s` delay between paged requests, per arXiv's API terms of use.
- Drop the now-unused `six` dependency.

## Unchanged

- CLI: `sotawhat <keyword> [count]` (default 5).
- Output format (title, author, date, summary, link).
- The abstract-summarization behavior that prioritizes sentences with numbers / SOTA claims.
- Keyword-based CS-only filtering for plain English words, all-of-arXiv for jargon.

Tested locally across several keywords (`transformer`, `language model`, `perplexity`, `GAN`, `wikitext`) plus the no-result path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
